### PR TITLE
Added cross build for Scala 2.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: scala
 scala:
   - 2.11.12
+  - 2.12.7
 jdk:
   - oraclejdk8
   - oraclejdk9
-  - oraclejdk10
   - openjdk8
   - openjdk9
   - openjdk10

--- a/build.sbt
+++ b/build.sbt
@@ -18,16 +18,16 @@ name := "spark-states"
 
 version := "0.1"
 
-scalaVersion := "2.11.12"
+crossScalaVersions := Seq("2.11.12", "2.12.7")
 
-val sparkVersion = "2.3.1"
+val sparkVersion = "2.4.0"
 
 libraryDependencies ++= Seq(
 
   // general dependencies
   "org.apache.spark" %% "spark-sql" % sparkVersion % "provided",
   "org.apache.spark" %% "spark-streaming" % sparkVersion % "provided",
-  "org.rocksdb" % "rocksdbjni" % "5.14.2",
+  "org.rocksdb" % "rocksdbjni" % "5.17.2",
 
   // test dependencies
   "org.scalatest" %% "scalatest" % "3.0.5" % "test",


### PR DESCRIPTION
Please, use `sbt "+ package"` to create the JAR file for both Scala 2.11 and Scala 2.12.
Also, the versions of Apache Spark and RocksDB library were updated.
Here is some more information: https://www.scala-sbt.org/release/docs/Cross-Build.html 