### PR TITLE
Avoid initializing all versions' state in initStateStore method

### DIFF
--- a/src/main/scala/ru/chermenin/spark/sql/execution/streaming/state/RocksDbStateStoreProvider.scala
+++ b/src/main/scala/ru/chermenin/spark/sql/execution/streaming/state/RocksDbStateStoreProvider.scala
@@ -368,7 +368,7 @@ class RocksDbStateStoreProvider extends StateStoreProvider with Logging {
     def initStateStore(path: String): StateStore =
       new RocksDbStateStore(version, path, keySchema, valueSchema, localSnapshots, createCache(ttlSec))
 
-    val stateStore = versions.sorted(Ordering.Long.reverse)
+    val stateStore = versions.sorted(Ordering.Long.reverse).toStream
       .map(version => Try(loadDb(version)).map(initStateStore))
       .find(_.isSuccess).map(_.get)
       .getOrElse(initStateStore(getTempDir(getTempPrefix(), s".$version")))


### PR DESCRIPTION
Codes below iterates all versions to `initStateStore` which wastes a lot of time.

```scala
 val stateStore = versions.sorted(Ordering.Long.reverse)
    .map(version => Try(loadDb(version)).map(initStateStore))
   .find(_.isSuccess).map(_.get)
```

Only the nearest version is needed.