### PR TITLE
Implement query based timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/chermenin/spark-states.svg?branch=master)](https://travis-ci.org/chermenin/spark-states)
 [![CodeFactor](https://www.codefactor.io/repository/github/chermenin/spark-states/badge)](https://www.codefactor.io/repository/github/chermenin/spark-states)
 
-Custom State Stores for Apache Spark to keep data between micro-batches for stateful stream processing.
+State management extensions for Apache Spark to keep data across micro-batches during stateful stream processing.
 
 ### Motivation
 
@@ -11,11 +11,20 @@ Out of the box, Apache Spark has only one implementation of state store provider
 
 ### Usage
 
-To use the custom state store provider for your pipelines use the following additional configuration for the submit script:
+To use the custom state store provider for your pipelines use the following additional configuration for the submit script/ SparkConf:
 
     --conf spark.sql.streaming.stateStore.providerClass="ru.chermenin.spark.sql.execution.streaming.state.RocksDbStateStoreProvider"
-    
 Here is some more information about it: https://docs.databricks.com/spark/latest/structured-streaming/production.html
+
+Alternatively, you can use the `useRocksDBStateStore()` helper method in your application while creating the SparkSession,
+
+```
+import ru.chermenin.spark.sql.execution.streaming.state.implicits._
+
+val spark = SparkSession.builder().master(...).useRocksDBStateStore().getOrCreate()
+```
+Note: For the helper methods to be available, you must import the implicits as shown above.
+
 
 ### State Timeout
     
@@ -23,7 +32,8 @@ With semantics similar to those of `GroupState`/ `FlatMapGroupWithState`, state 
 
 Important points to note when using State Timeouts,
  
- * Timeout value is a global param across all the groups
+ * Timeouts can be set differently for each streaming query. This relies on `queryName` and its `checkpointLocation`.
+ * The poll trigger set on a streaming query may or may not be set to a different value than the state expiration.
  * Timeouts are currently based on processing time
  * The timeout will occur once 
     1) a fixed duration has elapsed after the entry's creation, or
@@ -33,12 +43,55 @@ Important points to note when using State Timeouts,
  * Since the processing time timeout is based on the clock time, it is affected by the variations in the system clock (i.e. time zone changes, clock skew, etc.)
  * Timeout may or may not be set to strict expiration at the slight cost of memory. More info [here](https://github.com/chermenin/spark-states/issues/1).
     
-To configure state timeout, additional configuration can be added,
+There are 2 different ways configure state timeout,
+ 1) Via additional configuration on SparkConf,
  
+    To set a processing time timeout for all streaming queries in strict mode.
+ 
+    ```
     --conf spark.sql.streaming.stateStore.stateExpirySecs=5
     --conf spark.sql.streaming.stateStore.strictExpire=true
-    
-Other state timeout related points,
+    ```
+        
+    To configure state timeout differently for each query the above configs can be modified to,
+     
+    ```
+    --conf spark.sql.streaming.stateStore.stateExpirySecs.queryName1=5
+    --conf spark.sql.streaming.stateStore.stateExpirySecs.queryName2=10
+        ...
+        ...
+    --conf spark.sql.streaming.stateStore.strictExpire=true
+    ```
+2) Via `stateTimeout()` helper method _(recommended way)_,
+
+    ```
+    import ru.chermenin.spark.sql.execution.streaming.state.implicits._
+   
+   val spark: SparkSession = ...
+   val streamingDF: DataFrame = ...
+   
+   streamingDF.writeStream
+         .format(...)
+         .outputMode(...)
+         .trigger(Trigger.ProcessingTime(1000L))
+         .queryName("myQuery1")
+         .option("checkpointLocation", "chkpntloc")
+         .stateTimeout(spark.conf, expirySecs = 5)
+         .start()
+   
+   spark.streams.awaitAnyTermination()
+    ```
+   Preferably, the `queryName` and `checkpointLocation` can be set directly via the `stateTimeout()` method, as below,
+   ```
+   streamingDF.writeStream
+        .format(...)
+        .outputMode(...)
+        .trigger(Trigger.ProcessingTime(1000L))
+        .stateTimeout(spark.conf, queryName="myQuery1", expirySecs = 5, checkpointLocation ="chkpntloc")
+        .start()
+   ```
+Note: If `queryName` is invalid/ unavailable, the streaming query will be tagged as `UN_NAMED` and timeout applicable will be as per the value of `spark.sql.streaming.stateStore.stateExpirySecs` (which defaults to -1, but can be overridden via SparkConf) 
+Other state timeout related points (applicable on global and query level),
  * For no timeout, i.e. infinite state, set `spark.sql.streaming.stateStore.stateExpirySecs=-1`
  * For stateless processing, i.e. no state, set `spark.sql.streaming.stateStore.stateExpirySecs=0`
 

--- a/src/main/scala/ru/chermenin/spark/sql/execution/streaming/state/implicits.scala
+++ b/src/main/scala/ru/chermenin/spark/sql/execution/streaming/state/implicits.scala
@@ -1,0 +1,65 @@
+package ru.chermenin.spark.sql.execution.streaming.state
+
+import org.apache.hadoop.fs.Path
+import org.apache.spark.sql.RuntimeConfig
+import org.apache.spark.sql.SparkSession.Builder
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.streaming.DataStreamWriter
+import ru.chermenin.spark.sql.execution.streaming.state.RocksDbStateStoreProvider._
+
+import scala.collection.mutable
+
+object implicits extends Serializable {
+
+  implicit class WriterImplicits[T](dsw: DataStreamWriter[T]) {
+
+    def stateTimeout(runtimeConfig: RuntimeConfig,
+                     queryName: String = "",
+                     expirySecs: Int = DEFAULT_STATE_EXPIRY_SECS.toInt,
+                     checkpointLocation: String = ""): DataStreamWriter[T] = {
+
+      val extraOptions = getExtraOptions
+      val name = queryName match {
+        case "" | null => extraOptions.getOrElse("queryName", UNNAMED_QUERY)
+        case _ => queryName
+      }
+
+      val location = new Path(checkpointLocation match {
+        case "" | null =>
+          extraOptions.getOrElse("checkpointLocation",
+            runtimeConfig.getOption(SQLConf.CHECKPOINT_LOCATION.key
+            ).getOrElse(throw new IllegalStateException(
+              "Checkpoint Location must be specified for State Expiry either " +
+                """through option("checkpointLocation", ...) or """ +
+                s"""SparkSession.conf.set("${SQLConf.CHECKPOINT_LOCATION.key}", ...)"""))
+          )
+        case _ => checkpointLocation
+      }, name)
+        .toUri.toString
+
+      runtimeConfig.set(s"$STATE_EXPIRY_SECS.$name", if (expirySecs < 0) -1 else expirySecs)
+
+      dsw
+        .queryName(name)
+        .option("checkpointLocation", location)
+    }
+
+    def getExtraOptions: mutable.HashMap[String, String] = {
+      val className = classOf[DataStreamWriter[T]]
+      val field = className.getDeclaredField("extraOptions")
+      field.setAccessible(true)
+
+      field.get(dsw).asInstanceOf[mutable.HashMap[String, String]]
+    }
+  }
+
+  implicit class SessionImplicits(sparkSessionBuilder: Builder) {
+
+    def useRocksDBStateStore(): Builder =
+      sparkSessionBuilder.config(SQLConf.STATE_STORE_PROVIDER_CLASS.key,
+        classOf[RocksDbStateStoreProvider].getCanonicalName)
+
+  }
+
+
+}

--- a/src/test/scala/ru/chermenin/spark/sql/execution/streaming/state/RocksDbStateStoreHelper.scala
+++ b/src/test/scala/ru/chermenin/spark/sql/execution/streaming/state/RocksDbStateStoreHelper.scala
@@ -26,6 +26,7 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
 import org.scalatest.PrivateMethodTester
 
+import scala.reflect.io.Path._
 import scala.util.Random
 
 object RocksDbStateStoreHelper extends PrivateMethodTester {
@@ -99,7 +100,13 @@ object RocksDbStateStoreHelper extends PrivateMethodTester {
 
   def minSnapshotToRetain(version: Int): Int = version - batchesToRetain + 1
 
-  def clearDB(file: File): Unit = {
+  def performCleanUp(pathSlice: String): Unit = {
+    ".".toDirectory.dirs
+      .filter(_.name.contains(pathSlice))
+      .foreach(x => clearDB(x.jfile))
+  }
+
+  private def clearDB(file: File): Unit = {
     if (file.isDirectory)
       file.listFiles.foreach(clearDB)
     if (file.exists && !file.delete)

--- a/src/test/scala/ru/chermenin/spark/sql/execution/streaming/state/RocksDbStateStoreHelper.scala
+++ b/src/test/scala/ru/chermenin/spark/sql/execution/streaming/state/RocksDbStateStoreHelper.scala
@@ -111,16 +111,17 @@ object RocksDbStateStoreHelper extends PrivateMethodTester {
 
   def size(store: StateStore): Long = store.iterator.size
 
-  def createSQLConf(stateTTLSec: Long, isStrict: Boolean): SQLConf = {
+  def createSQLConf(defaultTTL: Long = -1,
+                    isStrict: Boolean,
+                    configs: Map[String, String] = Map.empty): SQLConf = {
     val sqlConf: SQLConf = new SQLConf()
 
     sqlConf.setConfString("spark.sql.streaming.stateStore.providerClass",
       "ru.chermenin.spark.sql.execution.streaming.state.RocksDbStateStoreProvider")
 
-    sqlConf.setConfString(RocksDbStateStoreProvider.STATE_EXPIRY_SECS, stateTTLSec.toString)
+    sqlConf.setConfString(RocksDbStateStoreProvider.STATE_EXPIRY_SECS, defaultTTL.toString)
     sqlConf.setConfString(RocksDbStateStoreProvider.STATE_EXPIRY_STRICT_MODE, isStrict.toString)
 
     sqlConf
   }
-
 }

--- a/src/test/scala/ru/chermenin/spark/sql/execution/streaming/state/RocksDbStateTimeoutSuite.scala
+++ b/src/test/scala/ru/chermenin/spark/sql/execution/streaming/state/RocksDbStateTimeoutSuite.scala
@@ -27,7 +27,6 @@ import org.apache.spark.sql.internal.SQLConf
 import org.scalatest.{BeforeAndAfter, FunSuite}
 import ru.chermenin.spark.sql.execution.streaming.state.RocksDbStateStoreProvider.{DUMMY_VALUE, MapType}
 
-import scala.reflect.io.Path._
 import scala.util.Random
 
 /**
@@ -53,18 +52,14 @@ class RocksDbStateTimeoutSuite extends FunSuite with BeforeAndAfter {
     StateStore.stop()
     require(!StateStore.isMaintenanceRunning)
 
-    ".".toDirectory.dirs
-      .filter(_.name.contains(testDBLocation))
-      .foreach(x => clearDB(x.jfile))
+    performCleanUp(testDBLocation)
   }
 
   after {
     StateStore.stop()
     require(!StateStore.isMaintenanceRunning)
 
-    ".".toDirectory.dirs
-      .filter(_.name.contains(testDBLocation))
-      .foreach(x => clearDB(x.jfile))
+    performCleanUp(testDBLocation)
   }
 
   test("no timeout") {

--- a/src/test/scala/ru/chermenin/spark/sql/execution/streaming/state/RocksDbStateTimeoutSuite.scala
+++ b/src/test/scala/ru/chermenin/spark/sql/execution/streaming/state/RocksDbStateTimeoutSuite.scala
@@ -16,7 +16,6 @@
 
 package ru.chermenin.spark.sql.execution.streaming.state
 
-import java.io.File
 import java.util.concurrent.{ConcurrentHashMap, TimeUnit}
 
 import com.google.common.base.Ticker
@@ -28,6 +27,7 @@ import org.apache.spark.sql.internal.SQLConf
 import org.scalatest.{BeforeAndAfter, FunSuite}
 import ru.chermenin.spark.sql.execution.streaming.state.RocksDbStateStoreProvider.{DUMMY_VALUE, MapType}
 
+import scala.reflect.io.Path._
 import scala.util.Random
 
 /**
@@ -41,8 +41,9 @@ class RocksDbStateTimeoutSuite extends FunSuite with BeforeAndAfter {
 
   final val testDBLocation: String = "testdb"
 
-  def withTTLStore(ttl: Long, sqlConf: SQLConf)(f: (FakeTicker, StateStore) => Unit): Unit = {
-    val stateStore = createTTLStore(ttl, sqlConf)
+  def withTTLStore(ttl: Long, sqlConf: SQLConf, pathSuffix: String = "")
+                  (f: (FakeTicker, StateStore) => Unit): Unit = {
+    val stateStore = createTTLStore(ttl, sqlConf, testDBLocation + pathSuffix)
 
     f(stateStore._1, stateStore._2)
     stateStore._2.commit()
@@ -52,13 +53,18 @@ class RocksDbStateTimeoutSuite extends FunSuite with BeforeAndAfter {
     StateStore.stop()
     require(!StateStore.isMaintenanceRunning)
 
-    clearDB(new File(testDBLocation))
+    ".".toDirectory.dirs
+      .filter(_.name.contains(testDBLocation))
+      .foreach(x => clearDB(x.jfile))
   }
 
   after {
     StateStore.stop()
     require(!StateStore.isMaintenanceRunning)
-    clearDB(new File(testDBLocation))
+
+    ".".toDirectory.dirs
+      .filter(_.name.contains(testDBLocation))
+      .foreach(x => clearDB(x.jfile))
   }
 
   test("no timeout") {
@@ -168,7 +174,77 @@ class RocksDbStateTimeoutSuite extends FunSuite with BeforeAndAfter {
     })
   }
 
-  private def createTTLStore(ttl: Long, sqlConf: SQLConf): (FakeTicker, StateStore) = {
+  test("different timeouts for each streaming query (states)") {
+    // Each query creates its own state store, the SQLConf is the same
+    import RocksDbStateStoreProvider.STATE_EXPIRY_SECS
+    val query1 = "query1"
+    val timeout1 = 3
+
+    val query2 = "query2"
+    val timeout2 = 5
+
+    val sqlConf = createSQLConf(isStrict = true, configs = Map(
+      s"$STATE_EXPIRY_SECS.$query1" -> s"$timeout1",
+      s"$STATE_EXPIRY_SECS.$query2" -> s"$timeout2"
+    ))
+
+    withTTLStore(timeout1, sqlConf, "1")((ticker1, store1) => {
+      withTTLStore(timeout2, sqlConf, "2")((ticker2, store2) => {
+
+        // Same data is read by both queries
+        put(store1, "k1", 1)
+        put(store1, "k2", 1)
+        put(store2, "k1", 1)
+        put(store2, "k2", 1)
+
+        assert(size(store1) === 2)
+        assert(contains(store1, "k1"))
+        assert(contains(store1, "k2"))
+
+        assert(size(store2) === 2)
+        assert(contains(store2, "k1"))
+        assert(contains(store2, "k2"))
+
+        // Clock progression is the same for both queries
+        ticker1.advance(2, TimeUnit.SECONDS)
+        ticker2.advance(2, TimeUnit.SECONDS)
+
+        assert(size(store1) === 2)
+        assert(contains(store1, "k1"))
+        assert(contains(store1, "k2"))
+
+        assert(size(store2) === 2)
+        assert(contains(store2, "k1"))
+        assert(contains(store2, "k2"))
+
+        ticker1.advance(1, TimeUnit.SECONDS) // deadline met for query1
+        ticker2.advance(1, TimeUnit.SECONDS)
+
+        assert(size(store1) === 0)
+        assert(!contains(store1, "k1"))
+        assert(!contains(store1, "k2"))
+
+        assert(size(store2) === 2)
+        assert(contains(store2, "k1"))
+        assert(contains(store2, "k2"))
+
+        ticker1.advance(2, TimeUnit.SECONDS)
+        ticker2.advance(2, TimeUnit.SECONDS) // deadline met for query2
+
+        assert(size(store1) === 0)
+        assert(!contains(store1, "k1"))
+        assert(!contains(store1, "k2"))
+
+        assert(size(store2) === 0)
+        assert(!contains(store2, "k1"))
+        assert(!contains(store2, "k2"))
+
+
+      })
+    })
+  }
+
+  private def createTTLStore(ttl: Long, sqlConf: SQLConf, dbPath: String): (FakeTicker, StateStore) = {
 
     def createMockCache(ttl: Long, ticker: Ticker): MapType = {
       val loader = new CacheLoader[UnsafeRow, String] {
@@ -193,7 +269,7 @@ class RocksDbStateTimeoutSuite extends FunSuite with BeforeAndAfter {
     val cache = createMockCache(ttl, ticker)
 
     val provider = createStoreProvider(opId = Random.nextInt(), partition = Random.nextInt(), sqlConf = sqlConf)
-    val store = new provider.RocksDbStateStore(0, testDBLocation, keySchema, valueSchema, new ConcurrentHashMap, cache)
+    val store = new provider.RocksDbStateStore(0, dbPath, keySchema, valueSchema, new ConcurrentHashMap, cache)
 
     (ticker, store)
   }


### PR DESCRIPTION
Fixes #8 .

Addes the following new features,

1. Allows timout specification on query level using Spark Conf
```
--conf spark.sql.streaming.stateStore.stateExpirySecs.queryName1=5
--conf spark.sql.streaming.stateStore.stateExpirySecs.queryName2=10
```
2. Allows the use of helper method to change the state store provider,

```
import ru.chermenin.spark.sql.execution.streaming.state.implicits._

val spark = SparkSession.builder().master(...).useRocksDBStateStore().getOrCreate()
```

3. Allows the use of helper method to set state timeout,

```
streamingDF.writeStream
     .format(...)
     .outputMode(...)
     .trigger(Trigger.ProcessingTime(1000L))
     .stateTimeout(spark.conf, queryName="myQuery1", expirySecs = 5, checkpointLocation ="chkpntloc")
     .start()
```

Added test cases and updated README/ code documentation for the same.