### PR TITLE
Workflow for Stale PR and Issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,15 +11,13 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-message: >
-            Automated Message:
-            
-            We're closing this issue because it hasn't been updated in a while.
+            Automated Message: We're closing this issue because it hasn't been updated in a while.
             This isn't a judgement on the merit of the issue in any way. It's just
             a way of keeping the issue queue manageable.
             If you'd like to revive this issue, please reopen it and ask a
             committer to remove the Stale tag!
           stale-pr-message: >
-            We're closing this PR because it hasn't been updated in a while.
+            Automated Message: We're closing this PR because it hasn't been updated in a while.
             This isn't a judgement on the merit of the PR in any way. It's just
             a way of keeping the PR queue manageable.
             If you'd like to revive this PR, please reopen it and ask a

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,32 @@
+name: "Close stale PRs"
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: >
+            Automated Message:
+            
+            We're closing this issue because it hasn't been updated in a while.
+            This isn't a judgement on the merit of the issue in any way. It's just
+            a way of keeping the issue queue manageable.
+            If you'd like to revive this issue, please reopen it and ask a
+            committer to remove the Stale tag!
+          stale-pr-message: >
+            We're closing this PR because it hasn't been updated in a while.
+            This isn't a judgement on the merit of the PR in any way. It's just
+            a way of keeping the PR queue manageable.
+            If you'd like to revive this PR, please reopen it and ask a
+            committer to remove the Stale tag!
+          days-before-stale: 30
+          days-before-close: 15
+          stale-issue-label: 'stale-issue'
+          stale-pr-label: 'stale-pr'
+          exempt-issue-labels: 'awaiting-approval,work-in-progress'
+          exempt-pr-labels: 'awaiting-approval,work-in-progress'


### PR DESCRIPTION
This workflow will run every day at 00.00 UTC to check for any issues/ PRs that have been inactive for over 30 and will close them in another 15 days.

Additionally, the stale issues will be marked with `stale-issue` label and the stale PRs will be marked with `stale-pr` label. Issues/ PR having `awaiting-approval` or `work-in-progress` labels are excluded from this check.